### PR TITLE
Improve compile.sh robustness

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+set -euo pipefail
+
+# Ensure typst CLI is available
+if ! command -v typst >/dev/null 2>&1; then
+    echo "Error: typst CLI not found. Please install typst to continue." >&2
+    exit 1
+fi
 
 # Check if a file argument is provided
 if [ "$#" -eq 1 ]; then


### PR DESCRIPTION
## Summary
- halt on script errors and failed pipelines
- exit early if the `typst` CLI is not available

## Testing
- `./compile.sh docs/papers/my_paper.typ`

------
https://chatgpt.com/codex/tasks/task_e_686c66fea5b0832c9278cd50c32c5498